### PR TITLE
Fix gradient of ReLU for non-positive values

### DIFF
--- a/mlrose_hiive/neural/activation/relu.py
+++ b/mlrose_hiive/neural/activation/relu.py
@@ -33,5 +33,6 @@ def relu(x, deriv=False):
 
     if deriv:
         fx[np.where(fx > 0)] = 1
+        fx[np.where(fx <= 0)] = 0
 
     return fx


### PR DESCRIPTION
See https://stats.stackexchange.com/a/333400
In the current implementation, f'(x) is equal to x when x <= 0, which is incorrect.