### PR TITLE
Fix import error during install: moving version to setup.py

### DIFF
--- a/mlrose_hiive/__init__.py
+++ b/mlrose_hiive/__init__.py
@@ -28,21 +28,3 @@ from .runners import GARunner, MIMICRunner, RHCRunner, SARunner, NNGSRunner
 from .runners import (build_data_filename)
 from .generators import (MaxKColorGenerator, QueensGenerator, FlipFlopGenerator, TSPGenerator, KnapsackGenerator,
                          ContinuousPeaksGenerator)
-
-# PEP0440 compatible formatted version, see:
-# https://www.python.org/dev/peps/pep-0440/
-#
-# Generic release markers:
-#   X.Y
-#   X.Y.Z   # For bugfix releases
-#
-# Admissible pre-release markers:
-#   X.YaN   # Alpha release
-#   X.YbN   # Beta release
-#   X.YrcN  # Release Candidate
-#   X.Y     # Final release
-#
-# Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
-# 'X.Y.dev0' is the canonical version of 'X.Y.dev'
-#
-__version__ = '2.1.7'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@
 # License: BSD 3 clause
 
 from setuptools import setup
-import mlrose_hiive
 
 def readme():
     """
@@ -14,8 +13,7 @@ def readme():
     with open('README.md') as _file:
         return _file.read()
 
-
-VERSION = mlrose_hiive.__version__
+VERSION = '2.1.7'
 
 setup(name='mlrose_hiive',
       version=VERSION,


### PR DESCRIPTION
After PR #6, installing fails if numpy is not already installed.

This happens because the `import mlrose_hiive` in setup.py picking up `__version__` in `__init__.py` also imports other modules that may not be installed at that point - like installing into new venv or conda env which often happens in CI test systems (where I found the problem)

This PR moves the version string out of `__init__.py` back into `setup.py`.

I don't expect this exact solution to be accepted.  This PR is more to point out the problem and ask that this be done in a different way.

Here are some good links discussing possible approaches and discussing the pros/cons of each:

https://martin-thoma.com/python-package-versions/
https://packaging.python.org/guides/single-sourcing-package-version/

cc: @dstrube1
