### PR TITLE
Add import instruction to help first-time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install mlrose-hiive
 
 Once it is installed, simply import it like so:
 ```python
-import mlrose_hiive as mlrose
+import mlrose_hiive
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -33,8 +33,13 @@ The latest version can be installed using `pip`:
 pip install mlrose-hiive
 ```
 
+Once it is installed, simply import it like so:
+```python
+import mlrose_hiive as mlrose
+```
+
 ## Documentation
-The official mlrose documentation can be found [here](https://mlrose.readthedocs.io/). 
+The official mlrose documentation can be found [here](https://mlrose.readthedocs.io/).
 
 A Jupyter notebook containing the examples used in the documentation is also available [here](https://github.com/gkhayes/mlrose/blob/master/tutorial_examples.ipynb).
 


### PR DESCRIPTION
I was confused for a minute when I installed this library and then tried to do "import mlrose" as shown in the documentation.  After a while I figured out that this library is actually called mlrose_hiive.  So I suggest adding an example import statement to help first-time users who install this library and jump straight into the documentation, like I did.

No hard feelings though if you don't want to explicitly recommend that people call this library as if it were the original mlrose.