### PR TITLE
enable maximize for k colors

### DIFF
--- a/mlrose_hiive/fitness/max_k_color.py
+++ b/mlrose_hiive/fitness/max_k_color.py
@@ -37,13 +37,18 @@ class MaxKColor:
     The MaxKColor fitness function is suitable for use in discrete-state
     optimization problems *only*.
 
-    This is a cost minimization problem: lower scores are better than
+    If this is a cost minimization problem: lower scores are better than
     higher scores. That is, for a given graph, and a given number of colors,
     the challenge is to assign a color to each node in the graph such that
     the number of pairs of adjacent nodes of the same color is minimized.
+
+    If this is a cost maximization problem: higher scores are better than
+    lower scores. That is, for a given graph, and a given number of colors,
+    the challenge is to assign a color to each node in the graph such that
+    the number of pairs of adjacent nodes of different colors are maximized.
     """
 
-    def __init__(self, edges):
+    def __init__(self, edges, maximize=False):
 
         # Remove any duplicates from list
         edges = list({tuple(sorted(edge)) for edge in edges})
@@ -51,6 +56,7 @@ class MaxKColor:
         self.graph_edges = None
         self.edges = edges
         self.prob_type = 'discrete'
+        self.maximize = maximize
 
     def evaluate(self, state):
         """Evaluate the fitness of a state vector.
@@ -73,7 +79,11 @@ class MaxKColor:
         # This is NOT what the docs above say.
 
         edges = self.edges if self.graph_edges is None else self.graph_edges
-        fitness = sum(int(state[n1] == state[n2]) for (n1, n2) in edges)
+
+        if self.maximize:
+            fitness = sum(int(state[n1] == state[n2]) for (n1, n2) in edges)
+        else:
+            fitness = sum(int(state[n1] != state[n2]) for (n1, n2) in edges)
         """
         if fitness == 0:
             for i in range(len(edges)):

--- a/mlrose_hiive/generators/max_k_color_generator.py
+++ b/mlrose_hiive/generators/max_k_color_generator.py
@@ -5,7 +5,7 @@ import networkx as nx
 
 class MaxKColorGenerator:
     @staticmethod
-    def generate(seed, number_of_nodes=20, max_connections_per_node=4, max_colors=None):
+    def generate(seed, number_of_nodes=20, max_connections_per_node=4, max_colors=None, maximize=False):
 
         """
         >>> edges = [(0, 1), (0, 2), (0, 4), (1, 3), (2, 0), (2, 3), (3, 4)]
@@ -39,5 +39,5 @@ class MaxKColorGenerator:
                     break
 
         edges = [(s, f) for (s, f) in g.edges()]
-        problem = MaxKColorOpt(edges=edges, length=number_of_nodes, max_colors=max_colors, source_graph=g)
+        problem = MaxKColorOpt(edges=edges, length=number_of_nodes, maximize=maximize, max_colors=max_colors, source_graph=g)
         return problem

--- a/mlrose_hiive/opt_probs/max_k_color_opt.py
+++ b/mlrose_hiive/opt_probs/max_k_color_opt.py
@@ -29,7 +29,7 @@ class MaxKColorOpt(DiscreteOpt):
         self.length = length
 
         if fitness_fn is None:
-            fitness_fn = MaxKColor(edges)
+            fitness_fn = MaxKColor(edges, maximize)
 
         # set up initial state (everything painted one color)
         if source_graph is None:


### PR DESCRIPTION
A lot of the other algos support maximization and minimization. Since the evaluate function is trivial to swap (maximize the differences vs minimize the similarities), I threaded through the maximize flag and allowed it to be set from the generator and opt, while pivoting in the fitness function on if we are maximizing or not. Keeps behavior of minimizing by default.