### PR TITLE
include samples in setup packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name='mlrose_hiive',
                 'mlrose_hiive.opt_probs', 'mlrose_hiive.fitness', 'mlrose_hiive.algorithms.mutators',
                 'mlrose_hiive.neural', 'mlrose_hiive.neural.activation', 'mlrose_hiive.neural.fitness',
                 'mlrose_hiive.neural.utils', 'mlrose_hiive.decorators',
-                'mlrose_hiive.gridsearch'],
+                'mlrose_hiive.gridsearch', 'mlrose_hiive.samples'],
       install_requires=['numpy', 'scipy', 'scikit-learn', 'pandas', 'networkx', 'joblib'],
       python_requires='>=3',
       zip_safe=False)


### PR DESCRIPTION
Building from master gives `ModuleNotFoundError: No module named 'mlrose_hiive.samples'`. This resolves it but I see that samples is WIP so if you intend to remove it from `mlrose_hiive/__init__.py`, feel free to just close this. Just figured it might be good to include since it appears to break master. Let me know if I've missed something in building that would have resolved the error.