### PR TITLE
fix error save result on nn runner

### DIFF
--- a/mlrose_hiive/runners/_nn_runner_base.py
+++ b/mlrose_hiive/runners/_nn_runner_base.py
@@ -149,7 +149,7 @@ class _NNRunnerBase(_RunnerBase, GridSearchMixin, ABC):
         path = os.path.join(*filename_root.split('/')[:-1])
         filename_part = filename_root.split('/')[-1]
         if path[0] != '/':
-            path = f'{path}'
+            path = f'/{path}'
         # find all data frames output by this runner
         filenames = [fn for fn in os.listdir(path) if (filename_part in fn
                                                        and fn.endswith('.p')


### PR DESCRIPTION
Error:
<img width="884" alt="image" src="https://user-images.githubusercontent.com/1274916/195644435-ecc0f15d-258d-499c-8f4c-689f1ce6c875.png">

Fix:
Seems like this handling is missing the '/' in the beginning of the path.

Test:
Run locally, now the error is fixed. I also run the test suite as can be seen below.
<img width="582" alt="image" src="https://user-images.githubusercontent.com/1274916/195644786-1e3b8cdf-0d4b-40be-bacc-bbb9524fb13c.png">

cc: @hiive 