### PR TITLE
update max k color test

### DIFF
--- a/tests/test_fitness.py
+++ b/tests/test_fitness.py
@@ -191,10 +191,10 @@ class TestFitness(unittest.TestCase):
     @staticmethod
     def test_max_k_color():
         """Test MaxKColor fitness function"""
-        edges = [(0, 1), (0, 2), (0, 4), (1, 3), (2, 0), (2, 3), (3, 4)]
+        edges = [(0, 1), (0, 2), (0, 4), (1, 3), (2, 0), (2, 3), (3, 4), (0, 5)]
 
-        state = np.array([0, 1, 0, 1, 1])
-        assert MaxKColor(edges).evaluate(state) == 3
+        state = np.array([0, 1, 0, 1, 1, 1])
+        assert MaxKColor(edges).evaluate(state) == 4
 
     @staticmethod
     def test_custom_fitness():


### PR DESCRIPTION
The test currently has a graph with the same number of same color pairs as different color pairs.  I think this update will help clarify how the fitness function evaluates a state.

On a related note, I'm not sure the `MaxKColor` fitness function is implemented correctly.  From the MIMIC paper:

> Here, we define Max K-Coloring to be the task of finding a coloring that minimizes the number of adjacent pairs colored the
same.

So the task is to minimize the number of adjacent pairs of same color.  In the current implementation, when the `maximize` flag is set to true, the fitness function counts the number of pairs of same color.

```
        if self.maximize:
            fitness = sum(int(state[n1] == state[n2]) for (n1, n2) in edges)
        else:
            fitness = sum(int(state[n1] != state[n2]) for (n1, n2) in edges)
```


Maximizing this would result in all pairs being same color.