### PR TITLE
Fixing mlrose to work with latest version of JobLib

### DIFF
--- a/mlrose_hiive/runners/_nn_runner_base.py
+++ b/mlrose_hiive/runners/_nn_runner_base.py
@@ -8,8 +8,6 @@ import pandas as pd
 import numpy as np
 import pickle as pk
 
-from joblib.my_exceptions import WorkerInterrupt
-
 from mlrose_hiive import GridSearchMixin
 from mlrose_hiive.runners._runner_base import _RunnerBase
 
@@ -102,7 +100,7 @@ class _NNRunnerBase(_RunnerBase, GridSearchMixin, ABC):
             except:
                 pass
             return self.run_stats_df, self.curves_df, self.cv_results_df, sr
-        except WorkerInterrupt:
+        except KeyboardInterrupt:
             return None, None, None, None
         finally:
             self._tear_down()


### PR DESCRIPTION
Currently, HIIVE MLRose checks for a worker interrupt using the joblib.my_exceptions.WorkerInterruot. This went away back about 2 years ago and is no longer part of joblib. If you pull this library down with a newer version of Python, it will grab the newest version of joblib, which causes this library to break. This fix swapps the worker interrupt with the KeyboardInterrupt which is used in the Joblib code as a replacement in the one place that still raises an error: https://github.com/joblib/joblib/pull/1393/files