### PR TITLE
bug fix in fitness score for original backprop

### DIFF
--- a/mlrose_hiive/neural/utils/weights.py
+++ b/mlrose_hiive/neural/utils/weights.py
@@ -146,7 +146,7 @@ def gradient_descent_original(problem, max_attempts=10, max_iters=np.inf,
             best_state = next_state
 
         if curve:
-            fitness_curve.append(problem.get_fitness())
+            fitness_curve.append(problem.get_adjusted_fitness())
 
         problem.set_state(next_state)
 


### PR DESCRIPTION
When using original gradient descent and problem is set to minimize, the fitness curve is still the unadjusted increasing version.