### PR TITLE
six peaks bug/MIMIC slowness

### DIFF
--- a/mlrose_hiive/fitness/six_peaks.py
+++ b/mlrose_hiive/fitness/six_peaks.py
@@ -87,7 +87,7 @@ class SixPeaks(_DiscretePeaksBase):
 
         # Calculate R(X, T)
         _r = 0
-        _max_score = max(tail_0, head_1)
+        _max_score = max(head_0, head_1, tail_0, tail_1)
         if tail_0 > _t and head_1 > _t:
             _r = _n
         elif tail_1 > _t and head_0 > _t:
@@ -95,7 +95,7 @@ class SixPeaks(_DiscretePeaksBase):
             _max_score = max(tail_1, head_0)
 
         # Evaluate function
-        fitness = max(tail_0, head_1) + _r
+        fitness = _max_score + _r
 
         return fitness
 

--- a/mlrose_hiive/runners/mimic_runner.py
+++ b/mlrose_hiive/runners/mimic_runner.py
@@ -25,7 +25,7 @@ Example usage:
 class MIMICRunner(_RunnerBase):
 
     def __init__(self, problem, experiment_name, seed, iteration_list, population_sizes,
-                 keep_percent_list, max_attempts=500, generate_curves=True, use_fast_mimic=False, **kwargs):
+                 keep_percent_list, max_attempts=5, generate_curves=True, use_fast_mimic=True, **kwargs):
         super().__init__(problem=problem, experiment_name=experiment_name, seed=seed, iteration_list=iteration_list,
                          max_attempts=max_attempts, generate_curves=generate_curves,
                          **kwargs)


### PR DESCRIPTION
Fixes six peaks bug (2 additional global maxima - binary value of the candidate does not matters, just the structure)  
Fixes MIMIC runner 'slowness' (changed default max_attempts=5, use_fast_mimic=True)