### PR TITLE
fixing maximization condition for queens generator

### DIFF
--- a/mlrose_hiive/opt_probs/queens_opt.py
+++ b/mlrose_hiive/opt_probs/queens_opt.py
@@ -36,4 +36,6 @@ class QueensOpt(DiscreteOpt):
         self.set_state(state)
 
     def can_stop(self):
+        if self.maximize == 1.0:
+            return int(self.get_fitness()) == (self.length * (self.length-1)) / 2
         return int(self.get_fitness()) == 0


### PR DESCRIPTION
Was using the queens generator with a runner (see here for example https://github.com/hiive/mlrose/blob/master/problem_examples.ipynb)

It is built to work as a minimization problem. However it seems like everything has to be phrased as a maximization problem for this assignment. In order to do this, I set:

problem = QueensGenerator().generate(seed=seed, size=8)

problem.maximize = 1.0

Here however I ran into an issue where the examples will all run for the max number of examples, because the stopping condition in queens_opt (which is what is given from the QueensGenerator()) is simply int(self.get_fitness()) == 0

obviously this doesn't work for a maximization problem, so I updated it. The condition when you maximize the n queens is n choose 2, which is n!/(2!)(n-2!), which simplifies to n * (n-1) / 2