### PR TITLE
improvements to nncore and neural_network code, better compatibility with sklearn

### DIFF
--- a/mlrose_hiive/neural/_nn_core.py
+++ b/mlrose_hiive/neural/_nn_core.py
@@ -156,8 +156,10 @@ class _NNCore(_NNBase):
             fitness_curve, fitted_weights, loss = self._run_with_sa(init_weights, num_nodes, problem)
         elif self.algorithm == 'genetic_alg':
             fitness_curve, fitted_weights, loss = self._run_with_ga(problem)
-        else:  # Gradient descent case
+        elif self.algorithm == 'gradient_descent':
             fitness_curve, fitted_weights, loss = self._run_with_gd(init_weights, num_nodes, problem)
+        else:
+            raise NotImplementedError(f"This class is not designed to handle{self.algorithm}")
 
         # Save fitted weights and node list
         self.node_list = node_list
@@ -286,3 +288,11 @@ class _NNCore(_NNBase):
                                    is_classifier=self.is_classifier)
         self.predicted_probs = pp
         return y_pred
+
+    def predict_proba(self, X):
+        _ = self.predict(X)
+        y_prob_1 = np.array(self.predicted_probs)
+        if y_prob_1.shape[1] > 1:
+            return y_prob_1
+        else:
+            return np.concatenate((1 - y_prob_1, y_prob_1), axis=1)

--- a/mlrose_hiive/neural/neural_network.py
+++ b/mlrose_hiive/neural/neural_network.py
@@ -4,6 +4,8 @@
 # License: BSD 3 clause
 
 from sklearn.base import  ClassifierMixin
+from sklearn.preprocessing import OneHotEncoder
+
 
 from mlrose_hiive.algorithms.decay import GeomDecay
 from ._nn_core import _NNCore
@@ -129,4 +131,14 @@ class NeuralNetwork(_NNCore, ClassifierMixin):
             max_attempts=max_attempts,
             random_state=random_state,
             curve=curve)
+        self.classes_ = None
+        self.one_hot_encoder = OneHotEncoder()
 
+    def fit(self, X, y=None, init_weights=None):
+        ohe_y = self.one_hot_encoder.fit_transform(y).toarray()
+        self.classes_ = ohe_y.categories_
+        return super().fit(X=X, y=ohe_y, init_weights=init_weights)
+
+    def predict(self, X):
+        preds = super().predict(X=X)
+        return self.one_hot_encoder.inverse_transform(preds)

--- a/mlrose_hiive/neural/neural_network.py
+++ b/mlrose_hiive/neural/neural_network.py
@@ -142,4 +142,4 @@ class NeuralNetwork(_NNCore, ClassifierMixin):
 
     def predict(self, X):
         preds = super().predict(X=X)
-        return self.one_hot_encoder.inverse_transform(preds.flatten())
+        return self.one_hot_encoder.inverse_transform(preds).flatten()

--- a/mlrose_hiive/neural/neural_network.py
+++ b/mlrose_hiive/neural/neural_network.py
@@ -2,7 +2,7 @@
 
 # Author: Genevieve Hayes (modified by Andrew Rollings)
 # License: BSD 3 clause
-
+import numpy as np
 from sklearn.base import  ClassifierMixin
 from sklearn.preprocessing import OneHotEncoder
 
@@ -135,10 +135,11 @@ class NeuralNetwork(_NNCore, ClassifierMixin):
         self.one_hot_encoder = OneHotEncoder()
 
     def fit(self, X, y=None, init_weights=None):
-        ohe_y = self.one_hot_encoder.fit_transform(y).toarray()
+        y_arr = np.array(y).reshape(-1, 1)
+        ohe_y = self.one_hot_encoder.fit_transform(y_arr).toarray()
         self.classes_ = ohe_y.categories_
         return super().fit(X=X, y=ohe_y, init_weights=init_weights)
 
     def predict(self, X):
         preds = super().predict(X=X)
-        return self.one_hot_encoder.inverse_transform(preds)
+        return self.one_hot_encoder.inverse_transform(preds.flatten())


### PR DESCRIPTION
provides nn_core with predict_proba. gives neural_network a one hot encoder to make the internal expectation of one-hot-encoded yvals compatible with expected behavior of yvals in sklearn objects. Uses the categories_ attribute of the one-hot-encoder to set the classes_attribute. This is compatible with a single-feature multiclass y, but not multi-value classification (multiple output Y features).