### PR TITLE
Solve NeuralNetwork .classes_ attribute issue in newer versions of sk-learn

### DIFF
--- a/mlrose_hiive/algorithms/sa.py
+++ b/mlrose_hiive/algorithms/sa.py
@@ -149,7 +149,4 @@ def simulated_annealing(problem, schedule=GeomDecay(), max_attempts=10,
     best_fitness = problem.get_maximize()*problem.get_fitness()
     best_state = problem.get_state()
 
-    if curve:
-        return best_state, best_fitness, np.asarray(fitness_curve)
-    else:
-        return best_state, best_fitness
+    return best_state, best_fitness, np.asarray(fitness_curve) if curve else None

--- a/mlrose_hiive/neural/_nn_core.py
+++ b/mlrose_hiive/neural/_nn_core.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 from abc import abstractmethod
+from sklearn.preprocessing import LabelBinarizer
 from mlrose_hiive.algorithms.decay import GeomDecay
 from mlrose_hiive.algorithms.rhc import random_hill_climb
 from mlrose_hiive.algorithms.sa import simulated_annealing
@@ -107,6 +108,20 @@ class _NNCore(_NNBase):
             raise Exception("""Algorithm must be one of: 'random_hill_climb',
                     'simulated_annealing', 'genetic_alg',
                     'gradient_descent'.""")
+            
+    def _validate_input(self, X, y):
+        """
+        Add _classes attribute based on classes present in y.
+        """
+        
+        # Required for sk-learn 1.3+. Doesn't cause issues for lower versions.
+        # Copied from https://github.com/scikit-learn/scikit-learn/blob/5c4aa5d0d90ba66247d675d4c3fc2fdfba3c39ff/sklearn/neural_network/_multilayer_perceptron.py
+        # Note: no workaround found for multi-class labels, still doesn't work with f1 score.
+        
+        if (not hasattr(self, "classes_")):
+            self._label_binarizer = LabelBinarizer()
+            self._label_binarizer.fit(y)
+            self.classes_ = self._label_binarizer.classes_
 
     def fit(self, X, y=None, init_weights=None):
         """Fit neural network to data.
@@ -126,6 +141,7 @@ class _NNCore(_NNBase):
             If :code:`None`, then a random state is used.
         """
         self._validate()
+        self._validate_input(X, y)
 
         X, y = self._format_x_y_data(X, y)
 

--- a/tests/test_neural.py
+++ b/tests/test_neural.py
@@ -10,6 +10,7 @@ except:
     sys.path.append("..")
 import unittest
 import numpy as np
+from sklearn.model_selection import StratifiedShuffleSplit, learning_curve
 # The following functions/classes are not automatically imported at
 # initialization, so must be imported explicitly from neural.py and
 # activation.py.
@@ -463,6 +464,44 @@ class TestNeuralNetwork(unittest.TestCase):
 
         assert (np.array_equal(network.predict(X), labels)
                 and np.allclose(network.predicted_probs, probs, atol=0.0001))
+        
+    @staticmethod
+    def test_learning_curve():
+        """Test sk-learning learning curve method."""
+
+        network = NeuralNetwork(hidden_nodes=[2], activation='identity',
+                                algorithm='simulated_annealing',
+                                bias=True, is_classifier=True, curve=True,  # curve has to be true...
+                                learning_rate=1, clip_max=1,
+                                max_attempts=100)
+
+        X = np.array([[0, 1, 0, 1],
+                      [0, 0, 1, 0],
+                      [1, 1, 0, 1],
+                      [1, 0, 1, 1],
+                      [0, 0, 1, 1],
+                      [1, 0, 0, 0],
+                      [1, 1, 1, 0],
+                      [0, 1, 1, 0],
+                      [0, 0, 0, 1],
+                      [1, 1, 0, 0],
+                      [0, 1, 1, 1],
+                      [1, 0, 1, 0],
+                      [1, 1, 1, 1],
+                      [0, 0, 0, 0],
+                      [0, 1, 0, 0],
+                      [1, 0, 0, 1]])
+        y = np.array([1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0])
+
+        train_sizes = [0.5, 1.0]
+        cv = StratifiedShuffleSplit(n_splits=1, test_size=0.2, random_state=42)
+
+        train_sizes, train_scores, test_scores = learning_curve(network, X, y, 
+                                                                train_sizes=train_sizes, 
+                                                                cv=cv, 
+                                                                scoring='accuracy') # error_score = 'raise' raises the actual sk-learn errors
+        
+        assert not np.isnan(train_scores).any() and not np.isnan(test_scores).any() # Fails if all values are NaN
 
 
 class TestLinearRegression(unittest.TestCase):


### PR DESCRIPTION
Issue: In scikit-learn 1.3+, evaluation and scoring methods like `learning_curve` require a `.classes_` attribute for any classifier instance passed in.

Solution: This fix implements a `_validate_input` method in `NNCore` which is called in the `fit` method. This closely matches sk-learn's implementation in [`MLPClassifier`](https://github.com/scikit-learn/scikit-learn/blob/5c4aa5d0d90ba66247d675d4c3fc2fdfba3c39ff/sklearn/neural_network/_multilayer_perceptron.py#L1091).

Other updates: I found an issue in the `simulated_annealing` return method that was causing failed tests when `curve=False`. I corrected it to match return statements in the other algorithms.

Tests: I added a unit test to `TestNeuralNetwork` which tests `NeuralNetwork` input to sk-learn's `learning_curve` method. All tests are passing, including algorithm tests.

Other PRs: I noticed kotoroshinoto's [PR](https://github.com/hiive/mlrose/pull/31) is currently active for the same issue. I think my solution is slightly more comprehensive and follows sk-learn's practices well, but feel free to pick and choose.