### PR TITLE
Add FourPeaksGenerator class imports to init files

### DIFF
--- a/mlrose_hiive/__init__.py
+++ b/mlrose_hiive/__init__.py
@@ -27,7 +27,7 @@ from .opt_probs import DiscreteOpt, ContinuousOpt, KnapsackOpt, TSPOpt, QueensOp
 from .runners import GARunner, MIMICRunner, RHCRunner, SARunner, NNGSRunner, SKMLPRunner
 from .runners import (build_data_filename)
 from .generators import (MaxKColorGenerator, QueensGenerator, FlipFlopGenerator, TSPGenerator, KnapsackGenerator,
-                         ContinuousPeaksGenerator)
+                         ContinuousPeaksGenerator, FourPeaksGenerator)
 
 from .samples import SyntheticData
 from .samples import (plot_synthetic_dataset)

--- a/mlrose_hiive/generators/__init__.py
+++ b/mlrose_hiive/generators/__init__.py
@@ -9,3 +9,4 @@ from .flip_flop_generator import FlipFlopGenerator
 from .queens_generator import QueensGenerator
 from .tsp_generator import TSPGenerator
 from .continuous_peaks_generator import ContinuousPeaksGenerator
+from .four_peaks_generator import FourPeaksGenerator


### PR DESCRIPTION
Issue: I was just informed that I totally forgot to add imports for my `FourPeaksGenerator` class to the generators and source level init files in #33. Fixed! It's importable from any level now.