### PR TITLE
Completely terminate RHC when requested

### DIFF
--- a/mlrose_hiive/algorithms/rhc.py
+++ b/mlrose_hiive/algorithms/rhc.py
@@ -165,6 +165,11 @@ def random_hill_climb(problem, max_attempts=10, max_iters=np.inf, restarts=0,
         # break out if we can stop
         if problem.can_stop():
             break
+
+        # break out if requested
+        if not continue_iterating:
+            break
+
     best_fitness *= problem.get_maximize()
 
     return best_state, best_fitness, np.asarray(best_fitness_curve) if curve else None


### PR DESCRIPTION
Currently RHC does not terminate when the callback returns zero. 

Other RO algorithms do and seems like the behavior should be to terminate completely (to allow for algorithms to run up to a certain wallclock time then be stopped).